### PR TITLE
[Feat] 페이지 레이아웃 및 섹션 구조 구성 (SSG 대응)

### DIFF
--- a/app/pf/page.tsx
+++ b/app/pf/page.tsx
@@ -3,6 +3,8 @@ import IntroSection from './sections/IntroSection';
 import ProjectsSection from './sections/ProjectsSection';
 import SkillsSection from './sections/SkillsSection';
 
+export const dynamic = 'force-static';
+
 export default function PortFolioPage() {
   return (
     <main className="mx-auto max-w-3xl px-6 py-24 space-y-32">

--- a/app/pf/page.tsx
+++ b/app/pf/page.tsx
@@ -1,0 +1,15 @@
+import ContactSection from './sections/ContactSection';
+import IntroSection from './sections/IntroSection';
+import ProjectsSection from './sections/ProjectsSection';
+import SkillsSection from './sections/SkillsSection';
+
+export default function PortFolioPage() {
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-24 space-y-32">
+      <IntroSection />
+      <ProjectsSection />
+      <SkillsSection />
+      <ContactSection />
+    </main>
+  );
+}

--- a/app/pf/sections/ContactSection.tsx
+++ b/app/pf/sections/ContactSection.tsx
@@ -1,0 +1,7 @@
+export default function ContactSection() {
+  return (
+    <section id="contact">
+      <h2 className="text-3xl font-bold text-center">Contact</h2>
+    </section>
+  );
+}

--- a/app/pf/sections/IntroSection.tsx
+++ b/app/pf/sections/IntroSection.tsx
@@ -1,0 +1,9 @@
+export default function IntroSection() {
+  return (
+    <section id="intro">
+      <h1 className="text-4xl font-bold text-center">
+        Hi, I'm <span className="text-blue-500">ddh</span>
+      </h1>
+    </section>
+  );
+}

--- a/app/pf/sections/ProjectsSection.tsx
+++ b/app/pf/sections/ProjectsSection.tsx
@@ -1,0 +1,7 @@
+export default function ProjectsSection() {
+  return (
+    <section id="projects">
+      <h2 className="text-3xl font-bold text-center">Projects</h2>
+    </section>
+  );
+}

--- a/app/pf/sections/SkillsSection.tsx
+++ b/app/pf/sections/SkillsSection.tsx
@@ -1,0 +1,7 @@
+export default function SkillsSection() {
+  return (
+    <section id="skills">
+      <h2 className="text-3xl font-bold text-center">Skills</h2>
+    </section>
+  );
+}


### PR DESCRIPTION
## 📌 PR 요약
- 페이지 레이아웃 및 섹션 구조 구성 (SSG 대응)


---

## 🧩 변경 내용
- `/pf` 페이지의 SSG 렌더링 구조 설정
- 섹션 4개 (Intro, Projects, Skills, Contact) 구조 구성
- 레이아웃은 Tailwind 기준 `max-w-3xl` 중심으로 설정
---

